### PR TITLE
CADC-10477: zip download for vault - acceptance review changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation 'org.freemarker:freemarker:[2.3.31,2.4.0)'
     implementation 'org.apache.commons:commons-lang3:[3.11,4.0)'
     implementation 'org.opencadc:cadc-util:[1.5.7,2.0)'
-    implementation 'org.opencadc:cadc-vosui:[1.2.8,1.3.0)'
+    implementation 'org.opencadc:cadc-vosui:[1.2.9,1.3.0)'
     implementation 'org.opencadc:cadc-registry:[1.5.15,2.0)'
     implementation 'org.restlet.jee:org.restlet:[2.4.3,2.4.99)'
 


### PR DESCRIPTION
Uses cadc-vosui 1.2.9 with timer added to package generation popup so it disappears automatically (rather than requiring an extra click.)  Fixed bug where clicking on ZIP in the download menu while viewing arc nodes generated a 500 error popup (service call was still happening when it shouldn't have.) 